### PR TITLE
Better handling for shutdown cancel request

### DIFF
--- a/NOnion.Tests/MonohopCircuits.cs
+++ b/NOnion.Tests/MonohopCircuits.cs
@@ -14,7 +14,7 @@ namespace NOnion.Tests
     public class MonohopCircuits
     {
 
-        private readonly IPEndPoint torServer = IPEndPoint.Parse("199.184.246.250:443");
+        private readonly IPEndPoint torServer = IPEndPoint.Parse("85.214.141.24:9001");
 
         [Test]
         public async Task CanCreateMonohopCircuit()

--- a/NOnion/NOnion.fsproj
+++ b/NOnion/NOnion.fsproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <Compile Include="Constants.fs" />
+    <Compile Include="Utility\StreamUtil.fs" />
     <Compile Include="Utility\SemaphoreLocker.fs" />
     <Compile Include="Utility\SeqUtils.fs" />
     <Compile Include="Utility\DigestUtils.fs" />

--- a/NOnion/Network/TorGuard.fs
+++ b/NOnion/Network/TorGuard.fs
@@ -159,7 +159,7 @@ type TorGuard private (client: TcpClient, sslStream: SslStream) =
             | Some (_circuitId, command, body) ->
                 //FIXME: maybe continue instead of failing?
                 if command <> expectedCommandType then
-                    failwith (sprintf "Unexpected msg type %d" command)
+                    failwith (sprintf "Unexpected msg type %i" command)
 
                 use memStream = new MemoryStream (body)
                 use reader = new BinaryReader (memStream)
@@ -203,7 +203,10 @@ type TorGuard private (client: TcpClient, sslStream: SslStream) =
                                     with
                                         | :? ObjectDisposedException
                                         | :? OperationCanceledException -> ()
-                                | None -> failwith "Unknown circuit"
+                                | None ->
+                                    failwith (
+                                        sprintf "Unknown circuit, Id = %i" cid
+                                    )
 
                             return! readFromStream ()
                     }

--- a/NOnion/Utility/StreamUtil.fs
+++ b/NOnion/Utility/StreamUtil.fs
@@ -1,0 +1,51 @@
+﻿namespace NOnion.Utility
+
+open System
+open System.IO
+
+module StreamUtil =
+    let ReadFixedSize (stream: Stream) (count: int) =
+        async {
+            let! ct = Async.CancellationToken
+
+            try
+                let rec readUntilBufferIsFull buffer offset =
+                    async {
+                        if ct.IsCancellationRequested || not stream.CanRead then
+                            return None
+                        else
+                            let! filledBytes =
+                                stream.ReadAsync (
+                                    buffer,
+                                    offset,
+                                    count - offset,
+                                    ct
+                                )
+                                |> Async.AwaitTask
+
+                            if filledBytes = 0 then
+                                return None
+                            elif filledBytes + offset = count then
+                                return Some buffer
+                            else
+                                return!
+                                    readUntilBufferIsFull
+                                        buffer
+                                        (offset + filledBytes)
+                    }
+
+                let buffer = Array.zeroCreate count
+                return! readUntilBufferIsFull buffer 0
+            with
+                | :? ObjectDisposedException
+                | :? OperationCanceledException -> return None
+        }
+
+    let Write (stream: Stream) (buffer: array<byte>) =
+        async {
+            let! ct = Async.CancellationToken
+
+            return!
+                stream.WriteAsync (buffer, 0, buffer.Length, ct)
+                |> Async.AwaitTask
+        }


### PR DESCRIPTION
This commit tries to fix the issue regarding listening task,
getting continued after cancellationToken has already been set
and the TorGuard object is disposed which causes ObjectDisposedException
on sslStream