### PR TITLE
Add support for non-fast handshakes

### DIFF
--- a/NOnion.Tests/KDFTest.cs
+++ b/NOnion.Tests/KDFTest.cs
@@ -11,7 +11,7 @@ namespace NOnion.Tests
         public void LegacyKdfCalculationTest()
         {
             byte[] K0 = new byte[2 * Constants.HashLength];
-            var kdfResult = Kdf.computeLegacyKdf(K0);
+            var kdfResult = Kdf.ComputeLegacyKdf(K0);
 
             var expectedKeyHandshake =
                 Hex.ToByteArray("669B1C85ECBAFE23C999100F55A23E06BF59EAD7");

--- a/NOnion/Cells/CellCreate2.fs
+++ b/NOnion/Cells/CellCreate2.fs
@@ -1,0 +1,38 @@
+﻿namespace NOnion.Cells
+
+open Microsoft.FSharp.Core
+open System.IO
+
+open NOnion
+open NOnion.Utility
+
+// Specification (https://github.com/torproject/torspec/blob/main/tor-spec.txt#L466)
+type CellCreate2 =
+    {
+        HandshakeType: HandshakeType
+        HandshakeData: array<byte>
+    }
+
+    static member Deserialize (reader: BinaryReader) =
+        {
+            HandshakeType =
+                BinaryIO.ReadBigEndianUInt16 reader
+                |> LanguagePrimitives.EnumOfValue<uint16, HandshakeType>
+
+            HandshakeData =
+                BinaryIO.ReadBigEndianUInt16 reader |> int |> reader.ReadBytes
+        }
+        :> ICell
+
+    interface ICell with
+
+        member __.Command = 10uy
+
+        member self.Serialize writer =
+            self.HandshakeType |> uint16 |> BinaryIO.WriteUInt16BigEndian writer
+
+            self.HandshakeData.Length
+            |> uint16
+            |> BinaryIO.WriteUInt16BigEndian writer
+
+            writer.Write self.HandshakeData

--- a/NOnion/Cells/CellCreated2.fs
+++ b/NOnion/Cells/CellCreated2.fs
@@ -1,0 +1,34 @@
+﻿namespace NOnion.Cells
+
+open System.IO
+
+open NOnion.Utility
+
+type CellCreated2 =
+    private
+        {
+            HandshakeData: array<byte>
+        }
+
+    static member Deserialize (reader: BinaryReader) =
+        {
+            HandshakeData =
+                BinaryIO.ReadBigEndianUInt16 reader |> int |> reader.ReadBytes
+        }
+        :> ICell
+
+    interface ICell with
+
+        member __.Command = 11uy
+
+        member self.Serialize writer =
+            self.HandshakeData.Length
+            |> uint16
+            |> BinaryIO.WriteUInt16BigEndian writer
+
+            writer.Write self.HandshakeData
+
+    interface ICreatedCell with
+        member self.ServerHandshake = self.HandshakeData |> Array.take 32
+
+        member self.DerivativeKey = self.HandshakeData |> Array.skip 32

--- a/NOnion/Cells/CellCreatedFast.fs
+++ b/NOnion/Cells/CellCreatedFast.fs
@@ -5,10 +5,11 @@ open System.IO
 open NOnion
 
 type CellCreatedFast =
-    {
-        Y: array<byte>
-        DerivativeKeyData: array<byte>
-    }
+    private
+        {
+            Y: array<byte>
+            DerivativeKeyData: array<byte>
+        }
 
     static member Deserialize (reader: BinaryReader) =
         let y = reader.ReadBytes Constants.HashLength
@@ -27,3 +28,8 @@ type CellCreatedFast =
         member self.Serialize writer =
             writer.Write self.Y
             writer.Write self.DerivativeKeyData
+
+    interface ICreatedCell with
+        member self.ServerHandshake = self.Y
+
+        member self.DerivativeKey = self.DerivativeKeyData

--- a/NOnion/Cells/Command.fs
+++ b/NOnion/Cells/Command.fs
@@ -33,6 +33,12 @@ module Command =
     [<Literal>]
     let CreatedFast = 6uy
 
+    [<Literal>]
+    let Create2 = 10uy
+
+    [<Literal>]
+    let Created2 = 11uy
+
     let IsVariableLength (command: byte) : bool =
         command = 7uy || command >= 128uy
 
@@ -54,6 +60,8 @@ module Command =
         | Relay -> CellEncryptedRelay.Deserialize reader
         | Padding -> CellPadding.Deserialize reader
         | Destroy -> CellDestroy.Deserialize reader
+        | Create2 -> CellCreate2.Deserialize reader
+        | Created2 -> CellCreated2.Deserialize reader
         | _ -> raise <| NotImplementedException ()
 
     // Is there any non generic way for this?
@@ -68,4 +76,6 @@ module Command =
         | t when t = typeof<CellEncryptedRelay> -> Relay
         | t when t = typeof<CellPadding> -> Padding
         | t when t = typeof<CellDestroy> -> Destroy
+        | t when t = typeof<CellCreate2> -> Create2
+        | t when t = typeof<CellCreated2> -> Created2
         | _ -> raise <| NotImplementedException ()

--- a/NOnion/Cells/ICell.fs
+++ b/NOnion/Cells/ICell.fs
@@ -5,3 +5,7 @@
 type ICell =
     abstract Command : byte
     abstract Serialize : System.IO.BinaryWriter -> unit
+
+type ICreatedCell =
+    abstract ServerHandshake : array<byte>
+    abstract DerivativeKey : array<byte>

--- a/NOnion/Constants.fs
+++ b/NOnion/Constants.fs
@@ -1,5 +1,7 @@
 ﻿namespace NOnion
 
+open System.Text
+
 [<RequireQualifiedAccess>]
 module Constants =
 
@@ -63,3 +65,22 @@ module Constants =
     let internal DefaultStreamLevelWindowParams = (500, 50)
 
     let internal DeflateStreamHeaderLength = 2
+
+
+
+    // NTor Handshake Constants
+    let private NTorProtoIdStr = "ntor-curve25519-sha256-1"
+    let internal NTorProtoId = NTorProtoIdStr |> Encoding.ASCII.GetBytes
+    let internal NTorTMac = NTorProtoIdStr + ":mac" |> Encoding.ASCII.GetBytes
+
+    let internal NTorTKey =
+        NTorProtoIdStr + ":key_extract" |> Encoding.ASCII.GetBytes
+
+    let internal NTorTVerify =
+        NTorProtoIdStr + ":verify" |> Encoding.ASCII.GetBytes
+
+    let internal NTorMExpand =
+        NTorProtoIdStr + ":key_expand" |> Encoding.ASCII.GetBytes
+
+    let internal NTorAuthInputSuffix =
+        NTorProtoIdStr + "Server" |> Encoding.ASCII.GetBytes

--- a/NOnion/Crypto/Kdf/Kdf.fs
+++ b/NOnion/Crypto/Kdf/Kdf.fs
@@ -5,7 +5,7 @@ open System.Security.Cryptography
 open NOnion
 
 module Kdf =
-    let computeLegacyKdf (k0: array<byte>) : KdfResult =
+    let ComputeLegacyKdf (k0: array<byte>) : KdfResult =
         use sha1Engine = new SHA1Managed ()
 
         let rec innerCompute (i: byte) (state: array<byte>) =

--- a/NOnion/Directory/ServerDescriptorsDocument.fs
+++ b/NOnion/Directory/ServerDescriptorsDocument.fs
@@ -170,7 +170,10 @@ type ServerDescriptorEntry =
 
                     innerParse
                         { state with
-                            Fingerprint = readWord () |> Some
+                            Fingerprint =
+                                (readRestAsString ())
+                                    .Replace (" ", String.Empty)
+                                |> Some
                         }
                 | "hibernating" ->
                     lines.Dequeue () |> ignore

--- a/NOnion/HandshakeType.fs
+++ b/NOnion/HandshakeType.fs
@@ -1,0 +1,6 @@
+﻿namespace NOnion
+
+type HandshakeType =
+    | NTor = 2us
+    | Reserved = 1us
+    | TAP = 0us

--- a/NOnion/NOnion.fsproj
+++ b/NOnion/NOnion.fsproj
@@ -7,8 +7,10 @@
 
   <ItemGroup>
     <Compile Include="Constants.fs" />
+    <Compile Include="HandshakeType.fs" />
     <Compile Include="Utility\StreamUtil.fs" />
     <Compile Include="Utility\SemaphoreLocker.fs" />
+    <Compile Include="Utility\Base64Util.fs" />
     <Compile Include="Utility\SeqUtils.fs" />
     <Compile Include="Utility\DigestUtils.fs" />
     <Compile Include="Utility\BigIntegerSerialization.fs" />
@@ -32,7 +34,12 @@
     <Compile Include="Cells\CellCreatedFast.fs" />
     <Compile Include="Cells\CellEncryptedRelay.fs" />
     <Compile Include="Cells\CellPlainRelay.fs" />
+    <Compile Include="Cells\CellCreate2.fs" />
+    <Compile Include="Cells\CellCreated2.fs" />
     <Compile Include="Cells\Command.fs" />
+    <Compile Include="TorHandshakes\IHandshake.fs" />
+    <Compile Include="TorHandshakes\FastHandshake.fs" />
+    <Compile Include="TorHandshakes\NTorHandshake.fs" />
     <Compile Include="Network\ITorCircuit.fs" />
     <Compile Include="Network\ITorStream.fs" />
     <Compile Include="Network\CircuitState.fs" />

--- a/NOnion/Network/CircuitState.fs
+++ b/NOnion/Network/CircuitState.fs
@@ -3,12 +3,13 @@
 open System.Threading.Tasks
 
 open NOnion.Crypto
+open NOnion.TorHandshakes
 
 //TODO: Implement states like destroyed, truncated, etc...
 type CircuitState =
     | Initialized
-    | CreatingFast of
+    | Creating of
         circuitId: uint16 *
-        randomClientMaterial: array<byte> *
+        handshakeState: IHandshake *
         completionTask: TaskCompletionSource<uint16>
     | Created of circuitId: uint16 * cryptoState: TorCryptoState

--- a/NOnion/Network/TorCircuit.fs
+++ b/NOnion/Network/TorCircuit.fs
@@ -185,7 +185,7 @@ type TorCircuit (guard: TorGuard) =
                             let kdfResult =
                                 Array.concat [ randomClientMaterial
                                                createdMsg.Y ]
-                                |> Kdf.computeLegacyKdf
+                                |> Kdf.ComputeLegacyKdf
 
                             if kdfResult.KeyHandshake
                                <> createdMsg.DerivativeKeyData then

--- a/NOnion/TorHandshakes/FastHandshake.fs
+++ b/NOnion/TorHandshakes/FastHandshake.fs
@@ -1,0 +1,38 @@
+﻿namespace NOnion.TorHandshakes
+
+open System.Security.Cryptography
+
+open NOnion
+open NOnion.Crypto.Kdf
+
+type FastHandshake =
+    private
+        {
+            RandomClientMaterial: array<byte>
+        }
+
+    static member Create () =
+        let clientMaterial = Array.zeroCreate Constants.HashLength
+
+        RandomNumberGenerator
+            .Create()
+            .GetBytes clientMaterial
+
+        {
+            RandomClientMaterial = clientMaterial
+        }
+
+    interface IHandshake with
+        member self.GenerateClientMaterial () =
+            self.RandomClientMaterial
+
+        member self.GenerateKdfResult serverSideData =
+            let kdfResult =
+                Array.concat [ self.RandomClientMaterial
+                               serverSideData.ServerHandshake ]
+                |> Kdf.ComputeLegacyKdf
+
+            if kdfResult.KeyHandshake <> serverSideData.DerivativeKey then
+                failwith "Key handshake failed!"
+            else
+                kdfResult

--- a/NOnion/TorHandshakes/IHandshake.fs
+++ b/NOnion/TorHandshakes/IHandshake.fs
@@ -1,0 +1,8 @@
+﻿namespace NOnion.TorHandshakes
+
+open NOnion.Cells
+open NOnion.Crypto.Kdf
+
+type IHandshake =
+    abstract GenerateClientMaterial : unit -> array<byte>
+    abstract GenerateKdfResult : ICreatedCell -> KdfResult

--- a/NOnion/TorHandshakes/NTorHandshake.fs
+++ b/NOnion/TorHandshakes/NTorHandshake.fs
@@ -1,0 +1,103 @@
+﻿namespace NOnion.TorHandshakes
+
+open System.Security.Cryptography
+
+open Org.BouncyCastle.Crypto.Parameters
+open Org.BouncyCastle.Security
+open Org.BouncyCastle.Crypto.Generators
+open Org.BouncyCastle.Crypto.Agreement
+
+open NOnion
+open NOnion.Crypto.Kdf
+
+type NTorHandshake =
+    private
+        {
+            RandomClientPrivateKey: X25519PrivateKeyParameters
+            RandomClientPublicKey: X25519PublicKeyParameters
+            IdentityDigest: array<byte>
+            NTorOnionKey: X25519PublicKeyParameters
+        }
+
+
+    static member Create
+        (identityDigest: array<byte>)
+        (nTorOnionKey: array<byte>)
+        =
+
+        let privateKey, publicKey =
+            let keyPair =
+                let kpGen = X25519KeyPairGenerator ()
+                let random = SecureRandom ()
+                kpGen.Init (X25519KeyGenerationParameters random)
+                kpGen.GenerateKeyPair ()
+
+            keyPair.Private :?> X25519PrivateKeyParameters,
+            keyPair.Public :?> X25519PublicKeyParameters
+
+        {
+            IdentityDigest = identityDigest
+            NTorOnionKey = X25519PublicKeyParameters (nTorOnionKey, 0)
+            RandomClientPrivateKey = privateKey
+            RandomClientPublicKey = publicKey
+        }
+
+    interface IHandshake with
+        member self.GenerateClientMaterial () =
+            Array.concat [ self.IdentityDigest
+                           self.NTorOnionKey.GetEncoded ()
+                           self.RandomClientPublicKey.GetEncoded () ]
+
+        member self.GenerateKdfResult serverSideData =
+            let randomServerPublicKey =
+                X25519PublicKeyParameters (serverSideData.ServerHandshake, 0)
+
+            let keyAgreement = X25519Agreement ()
+            keyAgreement.Init self.RandomClientPrivateKey
+
+            let sharedSecretWithY, sharedSecretWithB =
+                Array.zeroCreate keyAgreement.AgreementSize,
+                Array.zeroCreate keyAgreement.AgreementSize
+
+            keyAgreement.CalculateAgreement (
+                randomServerPublicKey,
+                sharedSecretWithY,
+                0
+            )
+
+            keyAgreement.CalculateAgreement (
+                self.NTorOnionKey,
+                sharedSecretWithB,
+                0
+            )
+
+            let secretInput =
+                Array.concat [ sharedSecretWithY
+                               sharedSecretWithB
+                               self.IdentityDigest
+                               self.NTorOnionKey.GetEncoded ()
+                               self.RandomClientPublicKey.GetEncoded ()
+                               randomServerPublicKey.GetEncoded ()
+                               Constants.NTorProtoId ]
+
+            let calculateHmacSha256 (data: array<byte>) (key: array<byte>) =
+                use hmacSha256 = new HMACSHA256 (key)
+
+                hmacSha256.ComputeHash data
+
+            let verify = calculateHmacSha256 secretInput Constants.NTorTVerify
+
+            let authInput =
+                Array.concat [ verify
+                               self.IdentityDigest
+                               self.NTorOnionKey.GetEncoded ()
+                               randomServerPublicKey.GetEncoded ()
+                               self.RandomClientPublicKey.GetEncoded ()
+                               Constants.NTorAuthInputSuffix ]
+
+            let auth = calculateHmacSha256 authInput Constants.NTorTMac
+
+            if auth <> serverSideData.DerivativeKey then
+                failwith "Key handshake failed!"
+            else
+                Kdf.ComputeRfc5869Kdf secretInput

--- a/NOnion/Utility/Base64Util.fs
+++ b/NOnion/Utility/Base64Util.fs
@@ -1,0 +1,21 @@
+﻿namespace NOnion.Utility
+
+module Base64Util =
+    let private modulus = 4
+    let private paddingCharacter = "="
+
+    let FromString (input: string) =
+        (*
+         * Length of base64 strings should be divisble by 4 or they'll be padded with =
+         * According to tor directory spec, "The trailing '=' sign MAY be omitted from the base64 encoding"
+         * But .NET base64 implemetation rejects non-padded base64 strings, so we need to add the padding
+         * back before trying to decode it.
+         *)
+        let missingPadding = (input.Length % modulus)
+
+        if missingPadding > 0 then
+            input
+            + (String.replicate (modulus - missingPadding) paddingCharacter)
+        else
+            input
+        |> System.Convert.FromBase64String


### PR DESCRIPTION
CreateFast can only be used for first hop of a circuit and only If we don't know any routers identity (during bootstraping and before we have any consensus data) so we need to add support for nTor or legacy TAP or both to be able to create multi-hop circuits