### PR TITLE
CI: nuget package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,9 @@ on: [push, pull_request]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
+    env:
+      BASE_VERSION: "0.1.0"
     steps:
       - uses: actions/checkout@v2
         with:
@@ -38,3 +38,10 @@ jobs:
           # path taken from https://stackoverflow.com/a/65367006/544947
           $HOME/.dotnet/tools/fantomless --recurse .
           git diff --exit-code
+      - name: Package
+        run: |
+          git clone https://github.com/nblockchain/fsx
+          cd fsx
+          sudo ./scripts/CI/install_mono_from_microsoft_deb_packages.sh
+          cd ..
+          fsx/Tools/nugetPush.fsx $BASE_VERSION ${{secrets.NUGET_API_KEY}}

--- a/NOnion/NOnion.fsproj
+++ b/NOnion/NOnion.fsproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
     <OtherFlags>$(OtherFlags) --warnon:1182</OtherFlags>
   </PropertyGroup>
 
@@ -83,6 +84,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Chaos.NaCl\Chaos.NaCl\Chaos.NaCl-Portable.csproj" />
+    <ProjectReference Include="..\Chaos.NaCl\Chaos.NaCl\Chaos.NaCl-Portable.csproj" PrivateAssets="all" />
   </ItemGroup>
+
+  <Target Name="CopyProjectReferencesToPackage" DependsOnTargets="ResolveReferences">
+    <ItemGroup>
+      <BuildOutputInPackage Include="@(ReferenceCopyLocalPaths->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference'))" />
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
Chaos.Nacl is a project reference we use, dotnet pack presumes that it's
a nuget depdendency and references it as such; this behaviour is unwanted
here because we have custom changes in Chaos.Nacl and we want to ship
all the necessary dlls inside our packages.

More: https://github.com/NuGet/Home/issues/3891#issuecomment-377319939