### PR TITLE
Network: changed generic exceptions in TorGuard

### DIFF
--- a/NOnion/Exceptions.fs
+++ b/NOnion/Exceptions.fs
@@ -10,8 +10,16 @@ type NOnionException =
     new(msg: string, innerException: Exception) =
         { inherit Exception(msg, innerException) }
 
-type GuardConnectionFailedException(innerException: Exception) =
-    inherit NOnionException("Connecting to guard node failed", innerException)
+type GuardConnectionFailedException =
+    inherit NOnionException
+
+    new(innerException: Exception) =
+        { inherit NOnionException("Connecting to guard node failed",
+                                  innerException) }
+
+    new(message: string) =
+        { inherit NOnionException("Connecting to guard node failed: " + message) }
+
 
 type CircuitTruncatedException(reason: DestroyReason) =
     inherit NOnionException(sprintf "Circuit got truncated, reason %A" reason)


### PR DESCRIPTION
Changed generic exceptions in TorGuard to GuardConnectionFailedException
 in order to differentiate exceptions that result from bugs in code from those that
 result from bad connection or failure on the other end.
Added new constructor to GuardConnectionFailedException that accepts exception message.