### PR TITLE
Services: use typed exn for service introduction

### DIFF
--- a/NOnion/Cells/Relay/RelayIntroduceAck.fs
+++ b/NOnion/Cells/Relay/RelayIntroduceAck.fs
@@ -6,13 +6,6 @@ open NOnion
 open NOnion.Cells
 open NOnion.Utility
 
-
-type RelayIntroduceStatus =
-    | Success = 0us
-    | Failure = 1us
-    | BadMessageFormat = 2us
-    | RelayFailed = 3us
-
 type RelayIntroduceAck =
     {
         Status: RelayIntroduceStatus

--- a/NOnion/Exceptions.fs
+++ b/NOnion/Exceptions.fs
@@ -26,3 +26,6 @@ type UnsuccessfulHttpRequestException(statusCode: string) =
     inherit NOnionException(sprintf
                                 "Non-200 status code received, code: %s"
                                 statusCode)
+
+type UnsuccessfulIntroductionException(status: RelayIntroduceStatus) =
+    inherit NOnionException(sprintf "Unsuccessful introduction: %A" status)

--- a/NOnion/NOnion.fsproj
+++ b/NOnion/NOnion.fsproj
@@ -15,6 +15,7 @@
     <Compile Include="TorLogger.fs" />
     <Compile Include="Constants.fs" />
     <Compile Include="DestroyReason.fs" />
+    <Compile Include="RelayIntroduceStatus.fs" />
     <Compile Include="Exceptions.fs" />
     <Compile Include="HandshakeType.fs" />
     <Compile Include="Utility\FSharpUtil.fs" />

--- a/NOnion/RelayIntroduceStatus.fs
+++ b/NOnion/RelayIntroduceStatus.fs
@@ -1,0 +1,7 @@
+﻿namespace NOnion
+
+type RelayIntroduceStatus =
+    | Success = 0us
+    | Failure = 1us
+    | BadMessageFormat = 2us
+    | RelayFailed = 3us

--- a/NOnion/Services/TorServiceClient.fs
+++ b/NOnion/Services/TorServiceClient.fs
@@ -482,9 +482,8 @@ type TorServiceClient =
 
                         if ack.Status <> RelayIntroduceStatus.Success then
                             return
-                                failwithf
-                                    "Unsuccessful introduction: %A"
-                                    ack.Status
+                                raise
+                                <| UnsuccessfulIntroductionException ack.Status
                     }
 
                 do!


### PR DESCRIPTION
This commit changes the generic exception (happening after failed introduction attempt) to a typed exception so it can be easily caught and handled.