### PR TITLE
Handle IntroductionPoint death

### DIFF
--- a/NOnion.Tests/HiddenServicesTests.cs
+++ b/NOnion.Tests/HiddenServicesTests.cs
@@ -42,7 +42,7 @@ namespace NOnion.Tests
             var circuit = new TorCircuit(guard);
 
             await circuit.CreateAsync(CircuitNodeDetail.FastCreate);
-            await circuit.RegisterAsIntroductionPointAsync(FSharpOption<AsymmetricCipherKeyPair>.None, StubCallback);
+            await circuit.RegisterAsIntroductionPointAsync(FSharpOption<AsymmetricCipherKeyPair>.None, StubCallback, DisconnectionCallback);
         }
 
         private Task StubCallback(RelayIntroduce _)
@@ -50,6 +50,7 @@ namespace NOnion.Tests
             return Task.CompletedTask;
         }
 
+        private void DisconnectionCallback() { }
 
         [Test]
         [Retry(TestsRetryCount)]
@@ -114,7 +115,7 @@ namespace NOnion.Tests
             int descriptorUploadRetryLimit = 2;
 
             TorDirectory directory = await TorDirectory.BootstrapAsync(FallbackDirectorySelector.GetRandomFallbackDirectory(), new DirectoryInfo(Path.GetTempPath()));
- 
+
             TorLogger.Log("Finished bootstraping");
 
             SecureRandom random = new SecureRandom();
@@ -154,7 +155,7 @@ namespace NOnion.Tests
 
             ((IDisposable) host).Dispose();
         }
-        
+
         [Test]
         [Retry(TestsRetryCount)]
         public void CanEstablishAndCommunicateOverHSConnectionOnionStyle()

--- a/NOnion/Exceptions.fs
+++ b/NOnion/Exceptions.fs
@@ -20,7 +20,6 @@ type GuardConnectionFailedException =
     internal new(message: string) =
         { inherit NOnionException("Connecting to guard node failed: " + message) }
 
-
 type CircuitTruncatedException internal (reason: DestroyReason) =
     inherit NOnionException(sprintf "Circuit got truncated, reason %A" reason)
 

--- a/NOnion/Exceptions.fs
+++ b/NOnion/Exceptions.fs
@@ -37,6 +37,9 @@ type UnsuccessfulHttpRequestException internal (statusCode: string) =
 type UnsuccessfulIntroductionException internal (status: RelayIntroduceStatus) =
     inherit NOnionException(sprintf "Unsuccessful introduction: %A" status)
 
+type IntroductoinPointsKilledException() =
+    inherit NOnionException("Introduction points got disconnected, please try again!")
+
 type NOnionSocketException
     internal
     (

--- a/NOnion/Network/CircuitState.fs
+++ b/NOnion/Network/CircuitState.fs
@@ -34,7 +34,8 @@ type CircuitState =
         privateKey: Ed25519PrivateKeyParameters *
         publicKey: Ed25519PublicKeyParameters *
         completionTask: TaskCompletionSource<unit> *
-        callback: (RelayIntroduce -> Async<unit>)
+        callback: (RelayIntroduce -> Async<unit>) *
+        disconnectionCallback: (unit -> unit)
     | RegisteringAsRendezvousPoint of
         circuitId: uint16 *
         circuitNodes: List<TorCircuitNode> *
@@ -57,7 +58,8 @@ type CircuitState =
         circuitNodes: List<TorCircuitNode> *
         privateKey: Ed25519PrivateKeyParameters *
         publicKey: Ed25519PublicKeyParameters *
-        callback: (RelayIntroduce -> Async<unit>)
+        callback: (RelayIntroduce -> Async<unit>) *
+        disconnectionCallback: (unit -> unit)
     | ReadyAsRendezvousPoint of
         circuitId: uint16 *
         circuitNodes: List<TorCircuitNode>

--- a/NOnion/Network/CircuitState.fs
+++ b/NOnion/Network/CircuitState.fs
@@ -63,6 +63,7 @@ type CircuitState =
         circuitNodes: List<TorCircuitNode>
     | Destroyed of circuitId: uint16 * reason: DestroyReason
     | Truncated of circuitId: uint16 * reason: DestroyReason
+    | Disconnected of circuitId: uint16
 
 
     member self.Name =
@@ -79,3 +80,4 @@ type CircuitState =
         | ReadyAsRendezvousPoint _ -> "ReadyAsRendezvousPoint"
         | Destroyed _ -> "Destroyed"
         | Truncated _ -> "Truncated"
+        | Disconnected _ -> "Disconnected"

--- a/NOnion/Network/ITorCircuit.fs
+++ b/NOnion/Network/ITorCircuit.fs
@@ -4,3 +4,4 @@ open NOnion.Cells
 
 type ITorCircuit =
     abstract HandleIncomingCell: ICell -> Async<unit>
+    abstract HandleDestroyedGuard: unit -> unit

--- a/NOnion/Network/ITorStream.fs
+++ b/NOnion/Network/ITorStream.fs
@@ -4,3 +4,4 @@ open NOnion.Cells.Relay
 
 type ITorStream =
     abstract HandleIncomingData: RelayData -> Async<unit>
+    abstract HandleDestroyedCircuit: unit -> unit

--- a/NOnion/Network/TorCircuit.fs
+++ b/NOnion/Network/TorCircuit.fs
@@ -1234,16 +1234,12 @@ and TorCircuit
             async {
                 //FIXME: add exception handling to mailbox and remove reply from here?
                 let! handleRes =
-                    circuitOperationsMailBox.PostAndAsyncReply(
-                        (fun replyChannel ->
-                            CircuitOperation.HandleIncomingCell(
-                                self,
-                                cell,
-                                replyChannel
-                            )
-                        ),
-                        Constants.CircuitRendezvousTimeout.TotalMilliseconds
-                        |> int
+                    circuitOperationsMailBox.PostAndAsyncReply(fun replyChannel ->
+                        CircuitOperation.HandleIncomingCell(
+                            self,
+                            cell,
+                            replyChannel
+                        )
                     )
 
                 return UnwrapResult handleRes

--- a/NOnion/Network/TorStream.fs
+++ b/NOnion/Network/TorStream.fs
@@ -20,28 +20,28 @@ type private StreamReceiveMessage =
     }
 
 type private StreamControlMessage =
-    | End of replayChannel: AsyncReplyChannel<OperationResult<unit>>
+    | End of replyChannel: AsyncReplyChannel<OperationResult<unit>>
     | Send of
         array<byte> *
-        replayChannel: AsyncReplyChannel<OperationResult<unit>>
+        replyChannel: AsyncReplyChannel<OperationResult<unit>>
     | StartServiceConnectionProcess of
         port: int *
         streamObj: ITorStream *
-        replayChannel: AsyncReplyChannel<OperationResult<Task<uint16>>>
+        replyChannel: AsyncReplyChannel<OperationResult<Task<uint16>>>
     | StartDirectoryConnectionProcess of
         streamObj: ITorStream *
-        replayChannel: AsyncReplyChannel<OperationResult<Task<uint16>>>
+        replyChannel: AsyncReplyChannel<OperationResult<Task<uint16>>>
     | RegisterStream of
         streamObj: ITorStream *
         streamId: uint16 *
-        replayChannel: AsyncReplyChannel<OperationResult<unit>>
+        replyChannel: AsyncReplyChannel<OperationResult<unit>>
     | HandleRelayConnected of
-        replayChannel: AsyncReplyChannel<OperationResult<unit>>
+        replyChannel: AsyncReplyChannel<OperationResult<unit>>
     | HandleRelayEnd of
         message: RelayData *
         reason: EndReason *
-        replayChannelOpt: Option<AsyncReplyChannel<OperationResult<unit>>>
-    | SendSendMe of replayChannel: AsyncReplyChannel<OperationResult<unit>>
+        replyChannelOpt: Option<AsyncReplyChannel<OperationResult<unit>>>
+    | SendSendMe of replyChannel: AsyncReplyChannel<OperationResult<unit>>
 
 type TorStream(circuit: TorCircuit) =
 


### PR DESCRIPTION
Kill TorServiceHost and inform it about the death of IntroductionPoints. Currently, TorServiceHost doesn't care about IntroductionPoints' deaths, and continues even when it shouldn't.

