### PR TITLE
Network,Utility: remove usage of SemaphoreLocker

### DIFF
--- a/NOnion/Constants.fs
+++ b/NOnion/Constants.fs
@@ -82,6 +82,9 @@ module Constants =
     // Time limit used for Create and Extend operations
     let internal CircuitOperationTimeout = TimeSpan.FromSeconds 10.
 
+    // Time limit used for RendezvousJoin operation
+    let internal CircuitRendezvousTimeout = TimeSpan.FromMinutes 2.
+
     // Time limit used for StreamBegin operation
     let internal StreamCreationTimeout = TimeSpan.FromSeconds 10.
 

--- a/NOnion/Http/TorHttpClient.fs
+++ b/NOnion/Http/TorHttpClient.fs
@@ -7,6 +7,7 @@ open System.IO.Compression
 
 open NOnion
 open NOnion.Network
+open NOnion.Utility
 
 type TorHttpClient(stream: TorStream, host: string) =
 

--- a/NOnion/NOnion.fsproj
+++ b/NOnion/NOnion.fsproj
@@ -99,7 +99,7 @@
 
   <Target Name="CopyProjectReferencesToPackage" DependsOnTargets="ResolveReferences">
     <ItemGroup>
-      <BuildOutputInPackage Include="@(ReferenceCopyLocalPaths->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference'))" />
+      <BuildOutputInPackage Include="@(ReferenceCopyLocalPaths-&gt;WithMetadataValue('ReferenceSourceTarget', 'ProjectReference'))" />
     </ItemGroup>
   </Target>
 </Project>

--- a/NOnion/NOnion.fsproj
+++ b/NOnion/NOnion.fsproj
@@ -19,6 +19,8 @@
     <Compile Include="Exceptions.fs" />
     <Compile Include="HandshakeType.fs" />
     <Compile Include="Utility\FSharpUtil.fs" />
+    <Compile Include="Utility\ResultUtil.fs" />
+    <Compile Include="Utility\MailboxUtil.fs" />
     <Compile Include="Utility\StreamUtil.fs" />
     <Compile Include="Utility\SemaphoreLocker.fs" />
     <Compile Include="Utility\Base64Util.fs" />

--- a/NOnion/Network/StreamState.fs
+++ b/NOnion/Network/StreamState.fs
@@ -10,11 +10,9 @@ type StreamState =
         streamId: uint16 *
         completionTask: TaskCompletionSource<uint16>
     | Connected of streamId: uint16
-    | Ended of streamId: uint16 * reason: EndReason
 
     member self.Id =
         match self with
         | Connecting(streamId, _)
-        | Connected streamId
-        | Ended(streamId, _) -> string streamId
+        | Connected streamId -> string streamId
         | Initialized -> "TBD"

--- a/NOnion/Network/TorStream.fs
+++ b/NOnion/Network/TorStream.fs
@@ -9,11 +9,43 @@ open FSharpx.Collections
 open NOnion
 open NOnion.Cells.Relay
 open NOnion.Utility
+open MailboxResultUtil
+
+type private StreamReceiveMessage =
+    {
+        StreamBuffer: array<byte>
+        BufferOffset: int
+        BufferLength: int
+        ReplyChannel: AsyncReplyChannel<OperationResult<int>>
+    }
+
+type private StreamControlMessage =
+    | End of replayChannel: AsyncReplyChannel<OperationResult<unit>>
+    | Send of
+        array<byte> *
+        replayChannel: AsyncReplyChannel<OperationResult<unit>>
+    | StartServiceConnectionProcess of
+        port: int *
+        streamObj: ITorStream *
+        replayChannel: AsyncReplyChannel<OperationResult<Task<uint16>>>
+    | StartDirectoryConnectionProcess of
+        streamObj: ITorStream *
+        replayChannel: AsyncReplyChannel<OperationResult<Task<uint16>>>
+    | RegisterStream of
+        streamObj: ITorStream *
+        streamId: uint16 *
+        replayChannel: AsyncReplyChannel<OperationResult<unit>>
+    | HandleRelayConnected of
+        replayChannel: AsyncReplyChannel<OperationResult<unit>>
+    | HandleRelayEnd of
+        message: RelayData *
+        reason: EndReason *
+        replayChannel: AsyncReplyChannel<OperationResult<unit>>
+    | SendSendMe of replayChannel: AsyncReplyChannel<OperationResult<unit>>
 
 type TorStream(circuit: TorCircuit) =
 
     let mutable streamState: StreamState = StreamState.Initialized
-    let controlLock: SemaphoreLocker = SemaphoreLocker()
 
     let window: TorWindow = TorWindow Constants.DefaultStreamLevelWindowParams
 
@@ -25,99 +57,64 @@ type TorStream(circuit: TorCircuit) =
     let mutable isEOF: bool = false
 
     let incomingCells: BufferBlock<RelayData> = BufferBlock<RelayData>()
-    let receiveLock: SemaphoreLocker = SemaphoreLocker()
 
-    static member Accept (streamId: uint16) (circuit: TorCircuit) =
-        async {
-            let stream = TorStream circuit
-            stream.RegisterIncomingStream streamId
-
-            do! circuit.SendRelayCell streamId (RelayConnected Array.empty) None
-
-            sprintf
-                "TorStream[%i,%i]: incoming stream accepted"
-                streamId
-                circuit.Id
-            |> TorLogger.Log
-
-            return stream
-        }
-
-    member __.End() =
-        async {
-            let safeEnd() =
-                async {
-                    match streamState with
-                    | Connected streamId ->
-                        do!
-                            circuit.SendRelayCell
-                                streamId
-                                (RelayEnd EndReason.Done)
-                                None
-
-                        sprintf
-                            "TorStream[%i,%i]: sending stream end packet"
-                            streamId
-                            circuit.Id
-                        |> TorLogger.Log
-                    | _ ->
-                        failwith
-                            "Unexpected state when trying to end the stream"
-                }
-
-            return! controlLock.RunAsyncWithSemaphore safeEnd
-        }
-
-    member self.EndAsync() =
-        self.End() |> Async.StartAsTask
-
-
-    member __.SendData(data: array<byte>) =
-        async {
-            let safeSend() =
-                async {
-                    match streamState with
-                    | Connected streamId ->
-                        let dataChunks =
-                            SeqUtils.Chunk
-                                Constants.MaximumRelayPayloadLength
-                                data
-
-                        let rec sendChunks dataChunks =
-                            async {
-                                match Seq.tryHeadTail dataChunks with
-                                | None -> ()
-                                | Some(head, nextDataChunks) ->
-                                    circuit.LastNode.Window.PackageDecrease()
-
-                                    do!
-                                        circuit.SendRelayCell
-                                            streamId
-                                            (head
-                                             |> Array.ofSeq
-                                             |> RelayData.RelayData)
-                                            None
-
-                                    window.PackageDecrease()
-                                    do! nextDataChunks |> sendChunks
-                            }
-
-                        do! sendChunks dataChunks
-                    | _ ->
-                        failwith
-                            "Unexpected state when trying to send data over stream"
-                }
-
-            return! controlLock.RunAsyncWithSemaphore safeSend
-        }
-
-    member self.SendDataAsync data =
-        self.SendData data |> Async.StartAsTask
-
-    member self.ConnectToService(port: int) =
-        let startConnectionProcess() =
+    let rec StreamControlMailBoxProcessor
+        (inbox: MailboxProcessor<StreamControlMessage>)
+        =
+        let safeEnd() =
             async {
-                let streamId = circuit.RegisterStream self None
+                match streamState with
+                | Connected streamId ->
+                    do!
+                        circuit.SendRelayCell
+                            streamId
+                            (RelayEnd EndReason.Done)
+                            None
+
+                    sprintf
+                        "TorStream[%i,%i]: sending stream end packet"
+                        streamId
+                        circuit.Id
+                    |> TorLogger.Log
+                | _ -> failwith "Unexpected state when trying to end the stream"
+            }
+
+        let safeSend(data: array<byte>) =
+            async {
+                match streamState with
+                | Connected streamId ->
+                    let dataChunks =
+                        SeqUtils.Chunk Constants.MaximumRelayPayloadLength data
+
+                    let rec sendChunks dataChunks =
+                        async {
+                            match Seq.tryHeadTail dataChunks with
+                            | None -> ()
+                            | Some(head, nextDataChunks) ->
+                                let! lastNode = circuit.GetLastNode()
+                                lastNode.Window.PackageDecrease()
+
+                                do!
+                                    circuit.SendRelayCell
+                                        streamId
+                                        (head
+                                         |> Array.ofSeq
+                                         |> RelayData.RelayData)
+                                        None
+
+                                window.PackageDecrease()
+                                do! nextDataChunks |> sendChunks
+                        }
+
+                    do! sendChunks dataChunks
+                | _ ->
+                    failwith
+                        "Unexpected state when trying to send data over stream"
+            }
+
+        let startServiceConnectionProcess (port: int) (streamObj: ITorStream) =
+            async {
+                let streamId = circuit.RegisterStream streamObj None
 
                 let tcs = TaskCompletionSource()
 
@@ -142,46 +139,343 @@ type TorStream(circuit: TorCircuit) =
                 return tcs.Task
             }
 
+        let startDirectoryConnectionProcess(streamObj: ITorStream) =
+            async {
+                let streamId = circuit.RegisterStream streamObj None
+
+                let tcs = TaskCompletionSource()
+
+                streamState <- Connecting(streamId, tcs)
+
+                sprintf
+                    "TorStream[%i,%i]: creating a directory stream"
+                    streamId
+                    circuit.Id
+                |> TorLogger.Log
+
+                do!
+                    circuit.SendRelayCell
+                        streamId
+                        RelayData.RelayBeginDirectory
+                        None
+
+                return tcs.Task
+            }
+
+        let registerProcess (streamObj: ITorStream) (streamId: uint16) =
+            streamState <-
+                circuit.RegisterStream streamObj (Some streamId) |> Connected
+
+        let handleRelayConnected() =
+            match streamState with
+            | Connecting(streamId, tcs) ->
+                streamState <- Connected streamId
+                tcs.SetResult streamId
+
+                sprintf "TorStream[%i,%i]: connected!" streamId circuit.Id
+                |> TorLogger.Log
+            | _ ->
+                failwith "Unexpected state when receiving RelayConnected cell"
+
+        let handleRelayEnd (message: RelayData) (reason: EndReason) =
+            match streamState with
+            | Connecting(streamId, tcs) ->
+                sprintf
+                    "TorStream[%i,%i]: received end packet while connecting"
+                    streamId
+                    circuit.Id
+                |> TorLogger.Log
+
+                Failure(
+                    sprintf
+                        "Stream connection process failed! Reason: %s"
+                        (reason.ToString())
+                )
+                |> tcs.SetException
+            | Connected streamId ->
+                sprintf
+                    "TorStream[%i,%i]: received end packet while connected"
+                    streamId
+                    circuit.Id
+                |> TorLogger.Log
+
+                incomingCells.Post message |> ignore<bool>
+            | _ -> failwith "Unexpected state when receiving RelayEnd cell"
+
+        let sendSendMe() =
+            async {
+                match streamState with
+                | Connected streamId ->
+                    return!
+                        circuit.SendRelayCell
+                            streamId
+                            RelayData.RelaySendMe
+                            None
+                | _ ->
+                    failwith "Unexpected state when sending stream-level sendme"
+            }
+
         async {
-            let! connectionProcessTcs =
-                controlLock.RunAsyncWithSemaphore startConnectionProcess
+            let! cancellationToken = Async.CancellationToken
+            cancellationToken.ThrowIfCancellationRequested()
+
+            let! command = inbox.Receive()
+
+            match command with
+            | End replyChannel ->
+                do! safeEnd() |> TryExecuteAsyncAndReplyAsResult replyChannel
+            | Send(data, replyChannel) ->
+                do!
+                    safeSend data
+                    |> TryExecuteAsyncAndReplyAsResult replyChannel
+            | StartServiceConnectionProcess(port, streamObj, replyChannel) ->
+                do!
+                    startServiceConnectionProcess port streamObj
+                    |> TryExecuteAsyncAndReplyAsResult replyChannel
+            | StartDirectoryConnectionProcess(streamObj, replyChannel) ->
+                do!
+                    startDirectoryConnectionProcess(streamObj)
+                    |> TryExecuteAsyncAndReplyAsResult replyChannel
+            | RegisterStream(streamObj, streamId, replyChannel) ->
+                TryExecuteAndReplyAsResult
+                    replyChannel
+                    (fun _ -> registerProcess streamObj streamId)
+            | HandleRelayConnected replyChannel ->
+                TryExecuteAndReplyAsResult replyChannel handleRelayConnected
+            | HandleRelayEnd(message, reason, replyChannel) ->
+                TryExecuteAndReplyAsResult
+                    replyChannel
+                    (fun _ -> handleRelayEnd message reason)
+            | SendSendMe replyChannel ->
+                do! sendSendMe() |> TryExecuteAsyncAndReplyAsResult replyChannel
+
+            return! StreamControlMailBoxProcessor inbox
+        }
+
+    let streamControlMailBox =
+        MailboxProcessor.Start StreamControlMailBoxProcessor
+
+    let rec StreamReceiveMailBoxProcessor
+        (inbox: MailboxProcessor<StreamReceiveMessage>)
+        =
+        let currentBufferHasRemainingBytes() =
+            bufferLength > bufferOffset
+
+        let currentBufferRemainingBytes() =
+            bufferLength - bufferOffset
+
+        let readFromCurrentBuffer
+            (buffer: array<byte>)
+            (offset: int)
+            (len: int)
+            =
+            let readLength = min len (currentBufferRemainingBytes())
+            Array.blit currentBuffer bufferOffset buffer offset readLength
+            bufferOffset <- bufferOffset + readLength
+
+            readLength
+
+        let processIncomingCell() =
+            async {
+                let! nextCell = incomingCells.ReceiveAsync() |> Async.AwaitTask
+
+                match nextCell with
+                | RelayData data ->
+                    Array.blit data 0 currentBuffer 0 data.Length
+                    bufferOffset <- 0
+                    bufferLength <- data.Length
+
+                    window.DeliverDecrease()
+
+                    if window.NeedSendme() then
+
+                        let! sendResult =
+                            streamControlMailBox.PostAndAsyncReply
+                                StreamControlMessage.SendSendMe
+
+                        return UnwrapResult sendResult
+
+                | RelayEnd reason when reason = EndReason.Done ->
+                    TorLogger.Log(
+                        sprintf
+                            "TorStream[%i]: pushed EOF to consumer"
+                            circuit.Id
+                    )
+
+                    currentBuffer <- Array.empty
+                    bufferOffset <- 0
+                    bufferLength <- 0
+                    isEOF <- true
+
+                | RelayEnd reason ->
+                    return
+                        failwithf
+                            "Stream closed unexpectedly, reason = %s"
+                            (reason.ToString())
+                | _ ->
+                    return
+                        failwith "IncomingCells should not keep unrelated cells"
+            }
+
+        let rec fillBuffer() =
+            async {
+                do! processIncomingCell()
+
+                if isEOF || currentBufferHasRemainingBytes() then
+                    return ()
+                else
+                    return! fillBuffer()
+            }
+
+        let refillBufferIfNeeded() =
+            async {
+                if not isEOF then
+                    if currentBufferHasRemainingBytes() then
+                        return ()
+                    else
+                        return! fillBuffer()
+            }
+
+
+        let safeReceive(buffer: array<byte>, offset: int, length: int) =
+            async {
+                if length = 0 then
+                    return 0
+                else
+                    do! refillBufferIfNeeded()
+
+                    if isEOF then
+                        return -1
+                    else
+                        let rec tryRead bytesRead bytesRemaining =
+                            async {
+                                if bytesRemaining > 0 && not isEOF then
+                                    do! refillBufferIfNeeded()
+
+                                    let newBytesRead =
+                                        bytesRead
+                                        + (readFromCurrentBuffer
+                                            buffer
+                                            (offset + bytesRead)
+                                            (length - bytesRead))
+
+                                    let newBytesRemaining =
+                                        length - newBytesRead
+
+                                    if incomingCells.Count = 0 then
+                                        return newBytesRead
+                                    else
+                                        return!
+                                            tryRead
+                                                newBytesRead
+                                                newBytesRemaining
+                                else
+                                    return bytesRead
+                            }
+
+                        return! tryRead 0 length
+            }
+
+
+        async {
+            let! cancellationToken = Async.CancellationToken
+            cancellationToken.ThrowIfCancellationRequested()
+
+            let! {
+                     StreamBuffer = buffer
+                     BufferOffset = offset
+                     BufferLength = length
+                     ReplyChannel = replyChannel
+                 } = inbox.Receive()
+
+            do!
+                safeReceive(buffer, offset, length)
+                |> TryExecuteAsyncAndReplyAsResult replyChannel
+
+            return! StreamReceiveMailBoxProcessor inbox
+        }
+
+    let streamReceiveMailBox =
+        MailboxProcessor.Start StreamReceiveMailBoxProcessor
+
+    static member Accept (streamId: uint16) (circuit: TorCircuit) =
+        async {
+            let stream = TorStream circuit
+            do! stream.RegisterIncomingStream streamId
+
+            do! circuit.SendRelayCell streamId (RelayConnected Array.empty) None
+
+            sprintf
+                "TorStream[%i,%i]: incoming stream accepted"
+                streamId
+                circuit.Id
+            |> TorLogger.Log
+
+            return stream
+        }
+
+    member __.End() =
+        async {
+            let! sendResult =
+                streamControlMailBox.PostAndAsyncReply StreamControlMessage.End
+
+            return UnwrapResult sendResult
+        }
+
+    member self.EndAsync() =
+        self.End() |> Async.StartAsTask
+
+
+    member __.SendData(data: array<byte>) =
+        async {
+            let! sendResult =
+                streamControlMailBox.PostAndAsyncReply(fun replyChannel ->
+                    StreamControlMessage.Send(data, replyChannel)
+                )
+
+            return UnwrapResult sendResult
+        }
+
+    member self.SendDataAsync data =
+        self.SendData data |> Async.StartAsTask
+
+    member self.ConnectToService(port: int) =
+        async {
+            let! completionTaskRes =
+                streamControlMailBox.PostAndAsyncReply(
+                    (fun replyChannel ->
+                        StreamControlMessage.StartServiceConnectionProcess(
+                            port,
+                            self,
+                            replyChannel
+                        )
+                    ),
+                    Constants.StreamCreationTimeout.TotalMilliseconds |> int
+                )
 
             return!
-                connectionProcessTcs
+                completionTaskRes
+                |> UnwrapResult
                 |> Async.AwaitTask
                 |> FSharpUtil.WithTimeout Constants.StreamCreationTimeout
         }
 
     member self.ConnectToDirectory() =
         async {
-            let startConnectionProcess() =
-                async {
-                    let streamId = circuit.RegisterStream self None
-
-                    let tcs = TaskCompletionSource()
-
-                    streamState <- Connecting(streamId, tcs)
-
-                    sprintf
-                        "TorStream[%i,%i]: creating a directory stream"
-                        streamId
-                        circuit.Id
-                    |> TorLogger.Log
-
-                    do!
-                        circuit.SendRelayCell
-                            streamId
-                            RelayData.RelayBeginDirectory
-                            None
-
-                    return tcs.Task
-                }
-
-            let! connectionProcessTcs =
-                controlLock.RunAsyncWithSemaphore startConnectionProcess
+            let! completionTaskResult =
+                streamControlMailBox.PostAndAsyncReply(
+                    (fun replyChannel ->
+                        StreamControlMessage.StartDirectoryConnectionProcess(
+                            self,
+                            replyChannel
+                        )
+                    ),
+                    Constants.StreamCreationTimeout.TotalMilliseconds |> int
+                )
 
             return!
-                connectionProcessTcs
+                completionTaskResult
+                |> UnwrapResult
                 |> Async.AwaitTask
                 |> FSharpUtil.WithTimeout Constants.StreamCreationTimeout
         }
@@ -190,152 +484,32 @@ type TorStream(circuit: TorCircuit) =
         self.ConnectToDirectory() |> Async.StartAsTask
 
     member private self.RegisterIncomingStream(streamId: uint16) =
-        let registerProcess() =
-            streamState <-
-                circuit.RegisterStream self (Some streamId) |> Connected
+        async {
+            let! registerationResult =
+                streamControlMailBox.PostAndAsyncReply(fun replyChannel ->
+                    StreamControlMessage.RegisterStream(
+                        self,
+                        streamId,
+                        replyChannel
+                    )
+                )
 
-        controlLock.RunSyncWithSemaphore registerProcess
+            return UnwrapResult registerationResult
+        }
 
     member self.Receive (buffer: array<byte>) (offset: int) (length: int) =
         async {
-            let currentBufferHasRemainingBytes() =
-                bufferLength > bufferOffset
+            let! receiveResult =
+                streamReceiveMailBox.PostAndAsyncReply(fun replyChannel ->
+                    {
+                        StreamBuffer = buffer
+                        BufferOffset = offset
+                        BufferLength = length
+                        ReplyChannel = replyChannel
+                    }
+                )
 
-            let currentBufferRemainingBytes() =
-                bufferLength - bufferOffset
-
-            let readFromCurrentBuffer
-                (buffer: array<byte>)
-                (offset: int)
-                (len: int)
-                =
-                let readLength = min len (currentBufferRemainingBytes())
-                Array.blit currentBuffer bufferOffset buffer offset readLength
-                bufferOffset <- bufferOffset + readLength
-
-                readLength
-
-            let processIncomingCell() =
-                async {
-                    let! nextCell =
-                        incomingCells.ReceiveAsync() |> Async.AwaitTask
-
-                    match nextCell with
-                    | RelayData data ->
-                        Array.blit data 0 currentBuffer 0 data.Length
-                        bufferOffset <- 0
-                        bufferLength <- data.Length
-
-                        window.DeliverDecrease()
-
-                        if window.NeedSendme() then
-                            let sendSendMe() =
-                                async {
-                                    match streamState with
-                                    | Connected streamId ->
-                                        return!
-                                            circuit.SendRelayCell
-                                                streamId
-                                                RelayData.RelaySendMe
-                                                None
-                                    | _ ->
-                                        failwith
-                                            "Unexpected state when sending stream-level sendme"
-                                }
-
-                            do! controlLock.RunAsyncWithSemaphore sendSendMe
-
-                    | RelayEnd reason when reason = EndReason.Done ->
-                        TorLogger.Log(
-                            sprintf
-                                "TorStream[%s,%i]: pushed EOF to consumer"
-                                streamState.Id
-                                circuit.Id
-                        )
-
-                        currentBuffer <- Array.empty
-                        bufferOffset <- 0
-                        bufferLength <- 0
-                        isEOF <- true
-
-                        let markStreamAsEnded() =
-                            match streamState with
-                            | Connected streamId ->
-                                streamState <- Ended(streamId, reason)
-                            | _ -> ()
-
-                        controlLock.RunSyncWithSemaphore markStreamAsEnded
-                    | RelayEnd reason ->
-                        return
-                            failwithf
-                                "Stream closed unexpectedly, reason = %s"
-                                (reason.ToString())
-                    | _ ->
-                        return
-                            failwith
-                                "IncomingCells should not keep unrelated cells"
-                }
-
-            let rec fillBuffer() =
-                async {
-                    do! processIncomingCell()
-
-                    if isEOF || currentBufferHasRemainingBytes() then
-                        return ()
-                    else
-                        return! fillBuffer()
-                }
-
-            let refillBufferIfNeeded() =
-                async {
-                    if not isEOF then
-                        if currentBufferHasRemainingBytes() then
-                            return ()
-                        else
-                            return! fillBuffer()
-                }
-
-
-            let safeReceive() =
-                async {
-                    if length = 0 then
-                        return 0
-                    else
-                        do! refillBufferIfNeeded()
-
-                        if isEOF then
-                            return -1
-                        else
-                            let rec tryRead bytesRead bytesRemaining =
-                                async {
-                                    if bytesRemaining > 0 && not isEOF then
-                                        do! refillBufferIfNeeded()
-
-                                        let newBytesRead =
-                                            bytesRead
-                                            + (readFromCurrentBuffer
-                                                buffer
-                                                (offset + bytesRead)
-                                                (length - bytesRead))
-
-                                        let newBytesRemaining =
-                                            length - newBytesRead
-
-                                        if incomingCells.Count = 0 then
-                                            return newBytesRead
-                                        else
-                                            return!
-                                                tryRead
-                                                    newBytesRead
-                                                    newBytesRemaining
-                                    else
-                                        return bytesRead
-                                }
-
-                            return! tryRead 0 length
-                }
-
-            return! receiveLock.RunAsyncWithSemaphore safeReceive
+            return UnwrapResult receiveResult
         }
 
     member self.ReceiveAsync(buffer: array<byte>, offset: int, length: int) =
@@ -346,55 +520,23 @@ type TorStream(circuit: TorCircuit) =
             async {
                 match message with
                 | RelayConnected _ ->
-                    let handleRelayConnected() =
-                        match streamState with
-                        | Connecting(streamId, tcs) ->
-                            streamState <- Connected streamId
-                            tcs.SetResult streamId
+                    let! handleConnectedResult =
+                        streamControlMailBox.PostAndAsyncReply
+                            StreamControlMessage.HandleRelayConnected
 
-                            sprintf
-                                "TorStream[%i,%i]: connected!"
-                                streamId
-                                circuit.Id
-                            |> TorLogger.Log
-                        | _ ->
-                            failwith
-                                "Unexpected state when receiving RelayConnected cell"
-
-
-                    controlLock.RunSyncWithSemaphore handleRelayConnected
+                    return UnwrapResult handleConnectedResult
                 | RelayData _ -> incomingCells.Post message |> ignore<bool>
                 | RelaySendMe _ -> window.PackageIncrease()
                 | RelayEnd reason ->
-                    let handleRelayEnd() =
-                        match streamState with
-                        | Connecting(streamId, tcs) ->
-                            sprintf
-                                "TorStream[%i,%i]: received end packet while connecting"
-                                streamId
-                                circuit.Id
-                            |> TorLogger.Log
-
-                            streamState <- Ended(streamId, reason)
-
-                            Failure(
-                                sprintf
-                                    "Stream connection process failed! Reason: %s"
-                                    (reason.ToString())
+                    let! handleEndResult =
+                        streamControlMailBox.PostAndAsyncReply(fun replyChannel ->
+                            StreamControlMessage.HandleRelayEnd(
+                                message,
+                                reason,
+                                replyChannel
                             )
-                            |> tcs.SetException
-                        | Connected streamId ->
-                            sprintf
-                                "TorStream[%i,%i]: received end packet while connected"
-                                streamId
-                                circuit.Id
-                            |> TorLogger.Log
+                        )
 
-                            incomingCells.Post message |> ignore<bool>
-                        | _ ->
-                            failwith
-                                "Unexpected state when receiving RelayEnd cell"
-
-                    controlLock.RunSyncWithSemaphore handleRelayEnd
+                    return UnwrapResult handleEndResult
                 | _ -> ()
             }

--- a/NOnion/Utility/FSharpUtil.fs
+++ b/NOnion/Utility/FSharpUtil.fs
@@ -1,9 +1,11 @@
-﻿namespace NOnion
+﻿namespace NOnion.Utility
 
 open System
 open System.Runtime.ExceptionServices
 
 open FSharpx.Collections
+
+open NOnion
 
 module FSharpUtil =
     //Implementation copied from https://github.com/nblockchain/geewallet/blob/master/src/GWallet.Backend/FSharpUtil.fs

--- a/NOnion/Utility/MailboxUtil.fs
+++ b/NOnion/Utility/MailboxUtil.fs
@@ -2,7 +2,6 @@
 
 open System.Net.Sockets
 
-//FIXME: for some reason FSharpUtil is in NOnion namespace instead of NOnion.Utility
 open NOnion
 
 module internal MailboxResultUtil =

--- a/NOnion/Utility/MailboxUtil.fs
+++ b/NOnion/Utility/MailboxUtil.fs
@@ -1,0 +1,40 @@
+﻿namespace NOnion.Utility
+
+open System.Net.Sockets
+
+//FIXME: for some reason FSharpUtil is in NOnion namespace instead of NOnion.Utility
+open NOnion
+
+module internal MailboxResultUtil =
+    let HandleError<'T>
+        exn
+        (replyChannel: AsyncReplyChannel<OperationResult<'T>>)
+        =
+        match FSharpUtil.FindException<SocketException> exn with
+        | Some socketExn ->
+            NOnionSocketException socketExn :> exn
+            |> OperationResult.Failure
+            |> replyChannel.Reply
+        | None -> OperationResult.Failure exn |> replyChannel.Reply
+
+    let TryExecuteAsyncAndReplyAsResult<'T>
+        (replyChannel: AsyncReplyChannel<OperationResult<'T>>)
+        (job: Async<'T>)
+        =
+        async {
+            try
+                let! result = job
+                OperationResult.Ok result |> replyChannel.Reply
+            with
+            | exn -> HandleError exn replyChannel
+        }
+
+    let TryExecuteAndReplyAsResult<'T>
+        (replyChannel: AsyncReplyChannel<OperationResult<'T>>)
+        (job: unit -> 'T)
+        =
+        try
+            let result = job()
+            OperationResult.Ok result |> replyChannel.Reply
+        with
+        | exn -> HandleError exn replyChannel

--- a/NOnion/Utility/ResultUtil.fs
+++ b/NOnion/Utility/ResultUtil.fs
@@ -1,0 +1,19 @@
+﻿namespace NOnion.Utility
+
+//FIXME: for some reason FSharpUtil is in NOnion namespace instead of NOnion.Utility
+open NOnion
+
+// RequireQualifiedAccess is needed to prevent collision with
+// Failure function that creates general exceptions
+
+[<RequireQualifiedAccess>]
+type internal OperationResult<'T> =
+    | Ok of 'T
+    | Failure of exn
+
+[<AutoOpen>]
+module internal ResultUtil =
+    let UnwrapResult<'T>(resultObj: OperationResult<'T>) =
+        match resultObj with
+        | OperationResult.Ok result -> result
+        | OperationResult.Failure ex -> raise <| FSharpUtil.ReRaise ex


### PR DESCRIPTION
Locking mutable shared variables has caused
weird bugs which were exteremly hard to find/detect,
this commit removes the usage of SemaphoreLocker in
the network layer of NOnion and replaces it by using
MailBoxes which allows implementation of multi-writer,
single-reader access pattern.
