### PR TITLE
Network: rethrow IOException as NOnionException (Not Tested)

### DIFF
--- a/NOnion/Exceptions.fs
+++ b/NOnion/Exceptions.fs
@@ -50,3 +50,10 @@ type NOnionSocketException
             "Got socket exception during data transfer",
             innerException
         )
+
+type NOnionIOException internal (innerException: System.IO.IOException) =
+    inherit NOnionException
+        (
+            "Got IO exception during data transfer",
+            innerException
+        )

--- a/NOnion/Network/TorGuard.fs
+++ b/NOnion/Network/TorGuard.fs
@@ -137,7 +137,10 @@ type TorGuard private (client: TcpClient, sslStream: SslStream) =
                     match FSharpUtil.FindException<SocketException> exn with
                     | Some socketEx ->
                         return raise <| GuardConnectionFailedException socketEx
-                    | None -> return raise <| FSharpUtil.ReRaise exn
+                    | None ->
+                        match FSharpUtil.FindException<IOException> exn with
+                        | Some ioExp -> return raise <| NOnionIOException ioExp
+                        | None -> return raise <| FSharpUtil.ReRaise exn
 
             ipEndpoint.ToString()
             |> sprintf "TorGuard: ssl connection to %s guard node authenticated"


### PR DESCRIPTION
IOExcepion caused problems in geewallet as mentioned in [1]. This commit will fix this problem by catching the IOException and rethrowing it as NOnionException.

**I couldn't test this.**

[1] https://github.com/nblockchain/NOnion/issues/45