### PR TITLE
Services: ret NOnionException downloadDescriptor

### DIFF
--- a/NOnion/Exceptions.fs
+++ b/NOnion/Exceptions.fs
@@ -40,6 +40,9 @@ type UnsuccessfulIntroductionException internal (status: RelayIntroduceStatus) =
 type IntroductoinPointsKilledException() =
     inherit NOnionException("Introduction points got disconnected, please try again!")
 
+type DescriptorDownloadFailedException() =
+    inherit NOnionException("Can't download descriptor, all requests failed.")
+
 type NOnionSocketException
     internal
     (

--- a/NOnion/Services/TorServiceClient.fs
+++ b/NOnion/Services/TorServiceClient.fs
@@ -61,8 +61,7 @@ type TorServiceClient =
                             match responsibleDirs with
                             | [] ->
                                 return
-                                    failwith
-                                        "TorServiceClient: can't download descriptor, all requests failed."
+                                    raise <| DescriptorDownloadFailedException()
                             | hsDirectory :: tail ->
                                 try
                                     let! guardEndPoint, randomGuardNode =


### PR DESCRIPTION
Previously returned exception with failwith which returned System.Exception. Now it returns NOnionExceptoin.