### PR TITLE
Network: try-wtih with specific exceptions

### DIFF
--- a/NOnion/DestroyReason.fs
+++ b/NOnion/DestroyReason.fs
@@ -14,3 +14,4 @@ type DestroyReason =
     | Timeout = 10uy
     | Destoyed = 11uy
     | NoSuchService = 12uy
+    | DescriptionFail = 13uy

--- a/NOnion/Network/TorCircuit.fs
+++ b/NOnion/Network/TorCircuit.fs
@@ -336,7 +336,11 @@ and TorCircuit
                                  node)
                     | None ->
                         announceDeath()
-                        failwith "Decryption failed!"
+
+                        raise
+                        <| CircuitDestroyedException(
+                            DestroyReason.DescriptionFail
+                        )
 
                 decryptMessage encryptedRelayCell.EncryptedData nodes
             | _ -> failwith "Unexpected state when receiving relay cell"

--- a/NOnion/Network/TorGuard.fs
+++ b/NOnion/Network/TorGuard.fs
@@ -332,7 +332,7 @@ type TorGuard private (client: TcpClient, sslStream: SslStream) =
                             try
                                 do! circuit.HandleIncomingCell cell
                             with
-                            | ex ->
+                            | :? CircuitDestroyedException as ex ->
                                 sprintf
                                     "TorGuard: exception when trying to handle incoming cell type=%i, ex=%s"
                                     cell.Command
@@ -340,6 +340,7 @@ type TorGuard private (client: TcpClient, sslStream: SslStream) =
                                 |> TorLogger.Log
 
                                 self.KillChildCircuits()
+                            | ex -> return raise <| FSharpUtil.ReRaise ex
                         | None ->
                             self.KillChildCircuits()
                             failwithf "Unknown circuit, Id = %i" cid


### PR DESCRIPTION
Previously, this block had a generic try-with which is dangerous since it can cause unwanted behaviours and cause confusion for future developers.