### PR TITLE
Network: TorStream should inherit IO.Stream

### DIFF
--- a/NOnion.Tests/HiddenServicesTests.cs
+++ b/NOnion.Tests/HiddenServicesTests.cs
@@ -86,7 +86,7 @@ namespace NOnion.Tests
         {
             if (len - off <= 0) return 0;
 
-            var bytesRead = await stream.ReceiveAsync(buffer, off, len - off);
+            var bytesRead = await stream.ReadAsync(buffer, off, len - off);
 
             if (bytesRead == 0 || bytesRead == -1)
                 throw new Exception("Not enough data");
@@ -134,7 +134,7 @@ namespace NOnion.Tests
                 Task.Run(async () => {
                     var stream = await host.AcceptClientAsync();
                     var bytesToSendWithLength = BitConverter.GetBytes(dataToSendAndReceive.Length).Concat(dataToSendAndReceive).ToArray();
-                    await stream.SendDataAsync(bytesToSendWithLength);
+                    await stream.WriteAsync(bytesToSendWithLength, 0, bytesToSendWithLength.Length);
                     await stream.EndAsync();
                 });
 

--- a/NOnion/Constants.fs
+++ b/NOnion/Constants.fs
@@ -95,8 +95,6 @@ module Constants =
     // Time limit used for receving data in stream
     let internal StreamReceiveTimeout = TimeSpan.FromSeconds 1.
 
-    let internal HttpClientBufferSize = 1024
-
     let internal DefaultHttpHost = "127.0.0.1"
 
     // NTor Handshake Constants

--- a/NOnion/Directory/TorDirectory.fs
+++ b/NOnion/Directory/TorDirectory.fs
@@ -76,7 +76,7 @@ type TorDirectory =
                         )
 
                     let circuit = TorCircuit(guard)
-                    let stream = TorStream(circuit)
+                    use stream = new TorStream(circuit)
 
                     (*
                         * We always use FastCreate authentication because privacy is not important for mono-hop
@@ -216,7 +216,7 @@ type TorDirectory =
                     )
 
                 let circuit = TorCircuit(guard)
-                let stream = TorStream(circuit)
+                use stream = new TorStream(circuit)
 
                 (*
                  * We always use FastCreate authentication because privacy is not important for mono-hop
@@ -252,7 +252,7 @@ type TorDirectory =
                             circuit.Create CircuitNodeDetail.FastCreate
                             |> Async.Ignore
 
-                        let consensusStream = TorStream circuit
+                        use consensusStream = new TorStream(circuit)
                         do! consensusStream.ConnectToDirectory() |> Async.Ignore
 
                         let consensusHttpClient =
@@ -340,7 +340,7 @@ type TorDirectory =
                             (digestsChunk: array<string>)
                             =
                             async {
-                                let descriptorsStream = TorStream circuit
+                                use descriptorsStream = new TorStream(circuit)
 
                                 do!
                                     descriptorsStream.ConnectToDirectory()

--- a/NOnion/Http/TorHttpClient.fs
+++ b/NOnion/Http/TorHttpClient.fs
@@ -9,7 +9,7 @@ open NOnion
 open NOnion.Network
 open NOnion.Utility
 
-type TorHttpClient(stream: TorStream, host: string) =
+type TorHttpClient(stream: Stream, host: string) =
 
     // Receives all the data stream until it reaches EOF (until stream receive a RELAY_END)
     let ReceiveAll memStream =
@@ -90,9 +90,7 @@ type TorHttpClient(stream: TorStream, host: string) =
                 |> Map.ofArray
 
             match headersMap.TryGetValue "Content-Encoding" with
-            | false, _ ->
-                return
-                    failwith "GetAsString: Content-Encoding header is missing"
+            | false, _
             | true, "identity" -> return body |> Encoding.UTF8.GetString
             | true, "deflate" ->
                 // DeflateStream needs the zlib header to be chopped off first
@@ -180,8 +178,7 @@ type TorHttpClient(stream: TorStream, host: string) =
 
             match headersMap.TryGetValue "Content-Encoding" with
             | false, _ when body.Length = 0 -> return String.Empty
-            | false, _ ->
-                return failwith "PostString: Content-Encoding header is missing"
+            | false, _
             | true, "identity" -> return body |> Encoding.UTF8.GetString
             | true, "deflate" ->
                 // DeflateStream needs the zlib header to be chopped off first

--- a/NOnion/Network/TorStream.fs
+++ b/NOnion/Network/TorStream.fs
@@ -92,7 +92,7 @@ type TorStream(circuit: TorCircuit) =
                         data
                         |> Seq.skip offset
                         |> Seq.take length
-                        |> SeqUtils.Chunk Constants.MaximumRelayPayloadLength
+                        |> Seq.chunkBySize Constants.MaximumRelayPayloadLength
 
                     let rec sendChunks dataChunks =
                         async {

--- a/NOnion/Services/TorServiceClient.fs
+++ b/NOnion/Services/TorServiceClient.fs
@@ -92,7 +92,7 @@ type TorServiceClient =
                                             circuit.Extend hsDirectoryNode
                                             |> Async.Ignore
 
-                                        let dirStream = TorStream circuit
+                                        use dirStream = new TorStream(circuit)
 
                                         do!
                                             dirStream.ConnectToDirectory()
@@ -493,7 +493,9 @@ type TorServiceClient =
                     Async.Parallel [ introduceJob; rendezvousJoin ]
                     |> Async.Ignore
 
-                let serviceStream = TorStream rendezvousCircuit
+                // We can't use the "use" keyword since this stream needs
+                // to outlive this function.
+                let serviceStream = new TorStream(rendezvousCircuit)
                 do! serviceStream.ConnectToService port |> Async.Ignore
 
                 return

--- a/NOnion/Services/TorServiceHost.fs
+++ b/NOnion/Services/TorServiceHost.fs
@@ -384,7 +384,7 @@ type TorServiceHost
                     do! circuit.Extend randomMiddleNode |> Async.Ignore
                     do! circuit.Extend hsDirectoryNode |> Async.Ignore
 
-                    let dirStream = TorStream circuit
+                    use dirStream = new TorStream(circuit)
                     do! dirStream.ConnectToDirectory() |> Async.Ignore
 
                     let! _response =
@@ -811,6 +811,9 @@ type TorServiceHost
                 }
 
             let! (streamId, senderCircuit) = getConnectionRequest()
+            // We can't use the "use" keyword since this stream needs
+            // to outlive this function. Hopefully the caller will dispose
+            // this after they're done using it.
             let! stream = TorStream.Accept streamId senderCircuit
             return stream
         }

--- a/NOnion/Utility/SeqUtils.fs
+++ b/NOnion/Utility/SeqUtils.fs
@@ -1,12 +1,5 @@
 ﻿namespace NOnion.Utility
 
 module SeqUtils =
-    // Helper function copied from https://stackoverflow.com/a/21615676
-    let Chunk chunkSize sequence =
-        sequence
-        |> Seq.mapi(fun i x -> i / chunkSize, x)
-        |> Seq.groupBy fst
-        |> Seq.map(fun (_, g) -> Seq.map snd g)
-
     let TakeRandom count sequence =
         sequence |> Seq.sortBy(fun _ -> System.Guid.NewGuid()) |> Seq.take count


### PR DESCRIPTION
This commit adds IO.Stream as a parent class
to TorStream this extremely helps with compatibility
and lowers the number of necessary changes to end
users' code.
