### PR TITLE
Network: hide HS methods from public API

### DIFF
--- a/NOnion/Network/TorCircuit.fs
+++ b/NOnion/Network/TorCircuit.fs
@@ -1191,7 +1191,7 @@ and TorCircuit
     member self.CreateAsync guardDetailOpt =
         self.Create guardDetailOpt |> Async.StartAsTask
 
-    member __.Introduce(introduceMsg: RelayIntroduce) =
+    member internal __.Introduce(introduceMsg: RelayIntroduce) =
         async {
             let! completionTaskRes =
                 circuitOperationsMailBox.PostAndAsyncReply(
@@ -1211,7 +1211,7 @@ and TorCircuit
                 |> FSharpUtil.WithTimeout Constants.CircuitOperationTimeout
         }
 
-    member __.WaitingForRendezvousJoin
+    member internal __.WaitingForRendezvousJoin
         (clientRandomPrivateKey: X25519PrivateKeyParameters)
         (clientRandomPublicKey: X25519PublicKeyParameters)
         (introAuthPublicKey: Ed25519PublicKeyParameters)
@@ -1240,7 +1240,7 @@ and TorCircuit
 
         }
 
-    member __.Rendezvous
+    member internal __.Rendezvous
         (cookie: array<byte>)
         (clientRandomKey: X25519PublicKeyParameters)
         (introAuthPublicKey: Ed25519PublicKeyParameters)

--- a/NOnion/Network/TorStream.fs
+++ b/NOnion/Network/TorStream.fs
@@ -432,7 +432,7 @@ type TorStream(circuit: TorCircuit) =
     override _.Flush() =
         ()
 
-    static member Accept (streamId: uint16) (circuit: TorCircuit) =
+    static member internal Accept (streamId: uint16) (circuit: TorCircuit) =
         async {
             // We can't use the "use" keyword since this stream needs
             // to outlive this function.
@@ -461,7 +461,7 @@ type TorStream(circuit: TorCircuit) =
     member self.EndAsync() =
         self.End() |> Async.StartAsTask
 
-    member self.ConnectToService(port: int) =
+    member internal self.ConnectToService(port: int) =
         async {
             let! completionTaskRes =
                 streamControlMailBox.PostAndAsyncReply(


### PR DESCRIPTION
There are some HS-related methods in TorStream and TorCircuit which are not supposed to be called by users directly (they should be used by TorServiceClient and TorServiceHost), this commit marks them as internal.