### PR TITLE
Network,Directory,Http: naming scheme for async

### DIFF
--- a/NOnion/Http/TorHttpClient.fs
+++ b/NOnion/Http/TorHttpClient.fs
@@ -15,7 +15,7 @@ type TorHttpClient(stream: Stream, host: string) =
     let ReceiveAll memStream =
         stream.CopyToAsync memStream |> Async.AwaitTask
 
-    member __.GetAsString (path: string) (forceUncompressed: bool) =
+    member __.AsyncGetAsString (path: string) (forceUncompressed: bool) =
         async {
             let headers =
                 let supportedCompressionAlgorithms =
@@ -115,7 +115,7 @@ type TorHttpClient(stream: Stream, host: string) =
                         compressionMethod
         }
 
-    member __.PostString (path: string) (payload: string) =
+    member __.AsyncPostString (path: string) (payload: string) =
         async {
             let headers =
                 [
@@ -204,4 +204,4 @@ type TorHttpClient(stream: Stream, host: string) =
         }
 
     member self.GetAsStringAsync path forceUncompressed =
-        self.GetAsString path forceUncompressed |> Async.StartAsTask
+        self.AsyncGetAsString path forceUncompressed |> Async.StartAsTask

--- a/NOnion/Network/TorCircuit.fs
+++ b/NOnion/Network/TorCircuit.fs
@@ -223,7 +223,7 @@ and TorCircuit
                                 |> encryptMessage onionList
                             Early = early
                         }
-                        |> guard.Send circuitId
+                        |> guard.AsyncSend circuitId
 
                     match relayData with
                     | RelayData _
@@ -656,7 +656,7 @@ and TorCircuit
                             connectionCompletionSource
                         )
 
-                    do! guard.Send circuitId handshakeCell
+                    do! guard.AsyncSend circuitId handshakeCell
 
                     TorLogger.Log(
                         sprintf
@@ -1072,7 +1072,7 @@ and TorCircuit
             failwith
                 "Should not happen: can't get circuitId for non-initialized circuit."
 
-    member __.GetLastNode() =
+    member __.AsyncGetLastNode() =
         async {
             let! lastNodeResult =
                 circuitOperationsMailBox.PostAndAsyncReply
@@ -1081,7 +1081,7 @@ and TorCircuit
             return UnwrapResult lastNodeResult
         }
 
-    member __.SendRelayCell
+    member __.AsyncSendRelayCell
         (streamId: uint16)
         (relayData: RelayData)
         (customDestinationOpt: Option<TorCircuitNode>)
@@ -1100,7 +1100,7 @@ and TorCircuit
             return UnwrapResult sendResult
         }
 
-    member self.Create(guardDetailOpt: CircuitNodeDetail) =
+    member self.AsyncCreate(guardDetailOpt: CircuitNodeDetail) =
         async {
             let! completionTaskRes =
                 circuitOperationsMailBox.PostAndAsyncReply(
@@ -1121,7 +1121,7 @@ and TorCircuit
                 |> FSharpUtil.WithTimeout Constants.CircuitOperationTimeout
         }
 
-    member __.Extend(nodeDetail: CircuitNodeDetail) =
+    member __.AsyncExtend(nodeDetail: CircuitNodeDetail) =
         async {
             let! completionTaskRes =
                 circuitOperationsMailBox.PostAndAsyncReply(
@@ -1138,7 +1138,7 @@ and TorCircuit
                 |> FSharpUtil.WithTimeout Constants.CircuitOperationTimeout
         }
 
-    member __.RegisterAsIntroductionPoint
+    member __.AsyncRegisterAsIntroductionPoint
         (authKeyPairOpt: Option<AsymmetricCipherKeyPair>)
         callback
         disconnectionCallback
@@ -1164,7 +1164,7 @@ and TorCircuit
                 |> FSharpUtil.WithTimeout Constants.CircuitOperationTimeout
         }
 
-    member __.RegisterAsRendezvousPoint(cookie: array<byte>) =
+    member __.AsyncRegisterAsRendezvousPoint(cookie: array<byte>) =
         async {
             let! completionTaskRes =
                 circuitOperationsMailBox.PostAndAsyncReply(
@@ -1186,12 +1186,12 @@ and TorCircuit
         }
 
     member self.ExtendAsync nodeDetail =
-        self.Extend nodeDetail |> Async.StartAsTask
+        self.AsyncExtend nodeDetail |> Async.StartAsTask
 
     member self.CreateAsync guardDetailOpt =
-        self.Create guardDetailOpt |> Async.StartAsTask
+        self.AsyncCreate guardDetailOpt |> Async.StartAsTask
 
-    member __.Introduce(introduceMsg: RelayIntroduce) =
+    member __.AsyncIntroduce(introduceMsg: RelayIntroduce) =
         async {
             let! completionTaskRes =
                 circuitOperationsMailBox.PostAndAsyncReply(
@@ -1211,7 +1211,7 @@ and TorCircuit
                 |> FSharpUtil.WithTimeout Constants.CircuitOperationTimeout
         }
 
-    member __.WaitingForRendezvousJoin
+    member __.AsyncWaitingForRendezvousJoin
         (clientRandomPrivateKey: X25519PrivateKeyParameters)
         (clientRandomPublicKey: X25519PublicKeyParameters)
         (introAuthPublicKey: Ed25519PublicKeyParameters)
@@ -1240,7 +1240,7 @@ and TorCircuit
 
         }
 
-    member __.Rendezvous
+    member __.AsyncRendezvous
         (cookie: array<byte>)
         (clientRandomKey: X25519PublicKeyParameters)
         (introAuthPublicKey: Ed25519PublicKeyParameters)
@@ -1280,14 +1280,14 @@ and TorCircuit
 
         let disconnectCallback = fun () -> disconnectCallback.Invoke()
 
-        self.RegisterAsIntroductionPoint
+        self.AsyncRegisterAsIntroductionPoint
             authKeyPairOpt
             introduceCallback
             disconnectCallback
         |> Async.StartAsTask
 
     member self.RegisterAsRendezvousPointAsync(cookie: array<byte>) =
-        self.RegisterAsRendezvousPoint cookie |> Async.StartAsTask
+        self.AsyncRegisterAsRendezvousPoint cookie |> Async.StartAsTask
 
     member internal __.RegisterStream
         (stream: ITorStream)

--- a/NOnion/Network/TorGuard.fs
+++ b/NOnion/Network/TorGuard.fs
@@ -181,20 +181,20 @@ type TorGuard
             return guard
         }
 
-    static member NewClientWithIdentity ipEndpoint fingerprintOpt =
+    static member AsyncNewClientWithIdentity ipEndpoint fingerprintOpt =
         TorGuard.InnerNewClient ipEndpoint fingerprintOpt
 
     static member NewClientWithIdentityAsync ipEndpoint fingerprintOpt =
-        TorGuard.NewClientWithIdentity ipEndpoint fingerprintOpt
+        TorGuard.AsyncNewClientWithIdentity ipEndpoint fingerprintOpt
         |> Async.StartAsTask
 
-    static member NewClient ipEndpoint =
+    static member AsyncNewClient ipEndpoint =
         TorGuard.InnerNewClient ipEndpoint None
 
     static member NewClientAsync ipEndpoint =
-        TorGuard.NewClient ipEndpoint |> Async.StartAsTask
+        TorGuard.AsyncNewClient ipEndpoint |> Async.StartAsTask
 
-    member self.Send (circuitId: uint16) (cellToSend: ICell) =
+    member self.AsyncSend (circuitId: uint16) (cellToSend: ICell) =
         async {
             let! sendResult =
                 sendMailBox.PostAndAsyncReply(fun replyChannel ->
@@ -213,7 +213,7 @@ type TorGuard
         }
 
     member self.SendAsync (circuidId: uint16) (cellToSend: ICell) =
-        self.Send circuidId cellToSend |> Async.StartAsTask
+        self.AsyncSend circuidId cellToSend |> Async.StartAsTask
 
     member private __.ReceiveInternal() =
         async {
@@ -487,7 +487,7 @@ type TorGuard
             TorLogger.Log "TorGuard: started handshake process"
 
             do!
-                self.Send
+                self.AsyncSend
                     Constants.DefaultCircuitId
                     {
                         CellVersions.Versions =
@@ -521,7 +521,7 @@ type TorGuard
                     "Expected router address is not listed in NETINFO"
 
             do!
-                self.Send
+                self.AsyncSend
                     Constants.DefaultCircuitId
                     {
                         //Clients SHOULD send "0" as their timestamp, to avoid fingerprinting.


### PR DESCRIPTION
Rename TorStream, TorCircuit, TorGuard, TorDirectory, and TorHttpClient methods according to the following scheme:
for method is called Foo
Foo() should return 'T
FooAsync() should return Task<'T>
AsyncFoo() should return Async<'T>.